### PR TITLE
Fix flake8 warning:

### DIFF
--- a/flake8_blind_except.py
+++ b/flake8_blind_except.py
@@ -5,6 +5,7 @@ __version__ = '0.1.0'
 
 BLIND_EXCEPT_REGEX = re.compile(r'(except:)')  # noqa
 
+
 def check_blind_except(physical_line):
     if pep8.noqa(physical_line):
         return


### PR DESCRIPTION
    $ flake8 flake8_blind_except.py
    flake8_blind_except.py:8:1: E302 expected 2 blank lines, found 1