### PR TITLE
Remove setuptools from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     version=get_version(),
     author='Elijah Andrews',
     author_email='elijahcandrews@gmail.com',
-    install_requires=['setuptools'],
     entry_points={
         'flake8.extension': [
             'B90 = flake8_blind_except:check_blind_except'


### PR DESCRIPTION
This package simply doesn't require setuptools for installation.

- When installing from a wheel, setuptools isn't needed.
- When installing from an sdist and setuptools isn't installed, setup.py will fail to import setuptools on line 1.