### PR TITLE
Change flake8 code to BLE

### DIFF
--- a/flake8_blind_except.py
+++ b/flake8_blind_except.py
@@ -1,41 +1,37 @@
-try:
-    import pycodestyle
-except ImportError:
-    import pep8 as pycodestyle
 import re
 
 __version__ = '0.2.1'
 
 BLIND_EXCEPT_REGEX = re.compile(r'(^[ \t]*except(.*\b(Base)?Exception\b.*)?:)')  # noqa
 
+
 def check_blind_except(physical_line):
     """Check for blind except statements.
 
     >>> check_blind_except('except:')
-    (0, 'B901 blind except: statement')
+    (0, 'BLE901 blind except: statement')
     >>> check_blind_except('except Exception:')
-    (0, 'B902 blind except Exception: statement')
+    (0, 'BLE902 blind except Exception: statement')
     >>> check_blind_except('except  Exception as exc:')
-    (0, 'B902 blind except Exception: statement')
+    (0, 'BLE902 blind except Exception: statement')
     >>> check_blind_except('except ValueError, Exception as exc:')
-    (0, 'B902 blind except Exception: statement')
+    (0, 'BLE902 blind except Exception: statement')
     >>> check_blind_except('except Exception, ValueError as exc:')
-    (0, 'B902 blind except Exception: statement')
+    (0, 'BLE902 blind except Exception: statement')
     >>> check_blind_except('except BaseException as exc:')
-    (0, 'B902 blind except Exception: statement')
+    (0, 'BLE902 blind except Exception: statement')
     >>> check_blind_except('except GoodException as exc:  # except:')
     >>> check_blind_except('except ExceptionGood as exc:')
     >>> check_blind_except('except Exception')  # only trigger with trailing colon
     >>> check_blind_except('some code containing except: in string')
     """
-    if pycodestyle.noqa(physical_line):
-        return
     match = BLIND_EXCEPT_REGEX.search(physical_line)
     if match:
         if match.group(2) is None:
-            return match.start(), 'B901 blind except: statement'
+            return match.start(), 'BLE901 blind except: statement'
         else:
-            return match.start(), 'B902 blind except Exception: statement'
+            return match.start(), 'BLE902 blind except Exception: statement'
+
 
 check_blind_except.name = 'flake8-blind-except'
 check_blind_except.version = __version__

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author_email='elijahcandrews@gmail.com',
     entry_points={
         'flake8.extension': [
-            'B90 = flake8_blind_except:check_blind_except'
+            'BLE90 = flake8_blind_except:check_blind_except'
         ],
     },
     url='https://github.com/elijahandrews/flake8-blind-except',


### PR DESCRIPTION
B901 and B902 are currently used by flake8-bugbear and set to ignore by default.
Changing the codes will avoid conflict with flake8-bugbear.

noqa detection is also removed as it is now handled natively by flake8 itself.

Fixes #15
Fixes #16